### PR TITLE
Fixes #39 - pagination back button is broken

### DIFF
--- a/palanaeum/templates/palanaeum/pagination_nav.html
+++ b/palanaeum/templates/palanaeum/pagination_nav.html
@@ -1,6 +1,6 @@
 <nav class="w3-bar">
     {% if page.has_previous %}
-        <a class="w3-bar-item" href="{{ url }}?page={{ page.prev_page_number }}&{{ page_params }}"><span class="fa fa-chevron-left"></span></a>
+        <a class="w3-bar-item" href="{{ url }}?page={{ page.previous_page_number }}&{{ page_params }}"><span class="fa fa-chevron-left"></span></a>
     {% endif %}
     {% for page_num in paginator.page_range %}
         {% if page_num == page.number %}


### PR DESCRIPTION
The fix is simple. Per the docs at
https://docs.djangoproject.com/en/2.0/topics/pagination/, paginator
pages refer to the previous page with property 'previous_page_number'
rather than 'prev_page_number'.