### PR TITLE
Fixed bug causing active filters returning no results to be ignored

### DIFF
--- a/palanaeum/models.py
+++ b/palanaeum/models.py
@@ -543,7 +543,7 @@ class Entry(TimeStampedModel, Content):
 
 class EntrySearchVector(models.Model):
     """
-    A special class storing serach vector for looking up entries.
+    A special class storing search vector for looking up entries.
     """
     entry = models.OneToOneField(Entry, on_delete=models.CASCADE)
     text_vector = pg_search.SearchVectorField()

--- a/palanaeum/search.py
+++ b/palanaeum/search.py
@@ -326,7 +326,12 @@ def execute_filters(filters: list) -> dict:
         if not search_filter:
             continue
 
-        for entry_id, score in search_filter.get_entry_ids():
+        search_filter_entry_ids = search_filter.get_entry_ids()
+        if not search_filter_entry_ids:
+            entries_by_filter.clear()
+            break
+
+        for entry_id, score in search_filter_entry_ids:
             entries_by_filter[search_filter].add(entry_id)
             entries_scores[entry_id] += score
 


### PR DESCRIPTION
If an active filter returned no results, the `set.intersection` function would not take that filter into account, and it would effectively be ignored. The easiest way to solve it seemed to be to just stop looking and discard anything already found if it turned out that even one active filter returned no results, since that would mean that the whole query should return nothing as well.

I also fixed a spelling mistake because I couldn't stop myself.