### PR TITLE
Pagination no longer appears on searches with no results (closes #32)

### DIFF
--- a/palanaeum/views.py
+++ b/palanaeum/views.py
@@ -372,7 +372,11 @@ def adv_search(request):
         entries, paginator, page = paginate_search_results(request, get_search_results(entries_scores, ordering))
         entries_found = paginator.count
         search_time = time.time() - start_time
-        to_show = page_numbers_to_show(paginator, page.number)
+        
+        if entries_scores:
+            to_show = page_numbers_to_show(paginator, page.number)
+        else:
+            to_show = []
 
     else:
         entries = []


### PR DESCRIPTION
If a search is valid but returns no results, preventing the pagination bars from being rendered removes some of the extraneous information on the 'no results' page.