### PR TITLE
Handle rejection of the only existing version of any entry gracefully

### DIFF
--- a/palanaeum/staff_views.py
+++ b/palanaeum/staff_views.py
@@ -572,8 +572,15 @@ def reject_entry(request, entry_id):
     logging.getLogger('palanaeum.staff').info("Rejected version content: %s",
                                               "<br/>".join(str(line) for line in last_version.lines.all()))
     last_version.reject()
-    messages.success(request, _("You have rejected changes to this entry. It is reverted to last approved version."))
-    return redirect('edit_entry', entry_id=entry_id)
+
+    if not entry.versions.exists():
+        event_id = entry.event.id
+        entry.delete()
+        messages.success(request, _("You have rejected changes to this entry. It was deleted because there weren't any remaining versions."))
+        return redirect('view_event_no_title', event_id=event_id)
+    else:
+        messages.success(request, _("You have rejected changes to this entry. It is reverted to last approved version."))
+        return redirect('edit_entry', entry_id=entry_id)
 
 
 @json_response

--- a/palanaeum/staff_views.py
+++ b/palanaeum/staff_views.py
@@ -488,17 +488,16 @@ def show_entry_history(request, entry_id):
 
     # Default newer is the newest version
     newer = entry.versions.last()
+    older = None
 
     if version_2 and version_1:
         newer = get_object_or_404(EntryVersion, pk=version_2, entry_id=entry_id)
         older = get_object_or_404(EntryVersion, pk=version_1, entry_id=entry_id)
-    elif newer != None:
+    elif newer is not None:
         # Default older is the last approved version
         # If there's no approved version, then it's the second to last version
         older = (entry.versions.filter(is_approved=True).exclude(pk=newer.pk).last() \
                 or entry.versions.exclude(pk=newer.pk).last() or newer)
-    else:
-        older = None
 
     if older is None or newer is None:
         raise Http404

--- a/palanaeum/staff_views.py
+++ b/palanaeum/staff_views.py
@@ -488,14 +488,17 @@ def show_entry_history(request, entry_id):
 
     # Default newer is the newest version
     newer = entry.versions.last()
-    # Default older is the last approved version
-    # If there's no approved version, then it's the second to last version
-    older = (entry.versions.filter(is_approved=True).exclude(pk=newer.pk).last() \
-             or entry.versions.exclude(pk=newer.pk).last() or newer)
 
     if version_2 and version_1:
         newer = get_object_or_404(EntryVersion, pk=version_2, entry_id=entry_id)
         older = get_object_or_404(EntryVersion, pk=version_1, entry_id=entry_id)
+    elif newer != None:
+        # Default older is the last approved version
+        # If there's no approved version, then it's the second to last version
+        older = (entry.versions.filter(is_approved=True).exclude(pk=newer.pk).last() \
+                or entry.versions.exclude(pk=newer.pk).last() or newer)
+    else:
+        older = None
 
     if older is None or newer is None:
         raise Http404

--- a/palanaeum/staff_views.py
+++ b/palanaeum/staff_views.py
@@ -575,6 +575,7 @@ def reject_entry(request, entry_id):
     if not entry.versions.exists():
         event_id = entry.event.id
         entry.delete()
+        logging.getLogger('palanaeum.staff').info("Entry %s was removed because its last remaining version was rejected.", entry.id)
         messages.success(request, _("You have rejected changes to this entry. It was deleted because there weren't any remaining versions."))
         return redirect('view_event_no_title', event_id=event_id)
     else:


### PR DESCRIPTION
As can be witnessed at https://wob.coppermind.net/entry/12768/history/, an entry without any existing version (approved or unapproved) will cause an internal server error when viewing its edit history.

This pull request aims to both gracefully handle the absence of a version for the edit history view as well as prevent that case in the first place. From a cursory glance, the only time a version gets deleted is when it gets rejected by a staff member. Hence, upon rejection of the last remaining version of an entry, the entry itself will be deleted.