### PR TITLE
Show the hidden page numbers when the ellipsis is clicked

### DIFF
--- a/palanaeum/static/palanaeum/css/palanaeum.css
+++ b/palanaeum/static/palanaeum/css/palanaeum.css
@@ -731,6 +731,10 @@ a.visibility-switch.hide .hide_text {
   .date-filter-table td {
     text-align: left; }
 
+.hidden-pg-num {
+  display:none!important;
+}
+
 .tag {
   display: inline-block;
   margin: 2px;

--- a/palanaeum/static/palanaeum/js/page_nav.js
+++ b/palanaeum/static/palanaeum/js/page_nav.js
@@ -51,9 +51,9 @@ $(function(){
     });
 });
 
-function show_hidden_pages(elipsis_element) {
-    elipsis_element.classList.add("hidden-pg-num");
-    element = elipsis_element.nextElementSibling; 
+function show_hidden_pages(elilpsis_element) {
+    ellipsis_element.classList.add("hidden-pg-num");
+    element = ellipsis_element.nextElementSibling; 
     while (element.classList.contains("hidden-pg-num"))
     {
       element.classList.remove("hidden-pg-num");

--- a/palanaeum/static/palanaeum/js/page_nav.js
+++ b/palanaeum/static/palanaeum/js/page_nav.js
@@ -50,3 +50,13 @@ $(function(){
         }
     });
 });
+
+function show_hidden_pages(elipsis_element) {
+    elipsis_element.classList.add("hidden-pg-num");
+    element = elipsis_element.nextElementSibling; 
+    while (element.classList.contains("hidden-pg-num"))
+    {
+      element.classList.remove("hidden-pg-num");
+      element = element.nextElementSibling; 
+    }
+}

--- a/palanaeum/templates/palanaeum/pagination_nav.html
+++ b/palanaeum/templates/palanaeum/pagination_nav.html
@@ -10,7 +10,7 @@
         {% elif page_num < 0 %}
             <a href="{{ url }}?page={{ page_num|stringformat:'d'|slice:'1:' }}&{{ page_params }}" class="button1 w3-bar-item hidden-pg-num">{{ page_num|stringformat:'d'|slice:'1:' }}</a>
         {% else %}
-            <a href="{{ url }}?page={{ page_num }}&{{ page_params }}" class="button1 w3-bar-item">{{ page_num}}</a>
+            <a href="{{ url }}?page={{ page_num }}&{{ page_params }}" class="button1 w3-bar-item">{{ page_num }}</a>
         {% endif %}
     {% endfor %}
     {% if page.has_next %}

--- a/palanaeum/templates/palanaeum/pagination_nav.html
+++ b/palanaeum/templates/palanaeum/pagination_nav.html
@@ -8,7 +8,7 @@
         {% elif page_num == 0 %}
             <div onclick="show_hidden_pages(this)" class="button1 w3-bar-item">&hellip;</div>
         {% elif page_num < 0 %}
-            <a href="{{ url }}?page={{ page_num|stringformat:'d'|slice:'1:' }}<&{{ page_params }}" class="button1 w3-bar-item hidden-pg-num">{{ page_num|stringformat:'d'|slice:'1:' }}</a>
+            <a href="{{ url }}?page={{ page_num|stringformat:'d'|slice:'1:' }}&{{ page_params }}" class="button1 w3-bar-item hidden-pg-num">{{ page_num|stringformat:'d'|slice:'1:' }}</a>
         {% else %}
             <a href="{{ url }}?page={{ page_num }}&{{ page_params }}" class="button1 w3-bar-item">{{ page_num}}</a>
         {% endif %}

--- a/palanaeum/templates/palanaeum/pagination_nav.html
+++ b/palanaeum/templates/palanaeum/pagination_nav.html
@@ -5,10 +5,12 @@
     {% for page_num in page_numbers_to_show %}
         {% if page_num == page.number %}
             <a href="#" class="button1-accent w3-bar-item">{{ page_num }}</a>
-        {% elif page_num == -1 %}
-            <a href="#" class="button1 w3-bar-item">&hellip;</a>
+        {% elif page_num == 0 %}
+            <div onclick="show_hidden_pages(this)" class="button1 w3-bar-item">&hellip;</div>
+        {% elif page_num < 0 %}
+            <a href="{{ url }}?page={{ page_num|stringformat:'d'|slice:'1:' }}<&{{ page_params }}" class="button1 w3-bar-item hidden-pg-num">{{ page_num|stringformat:'d'|slice:'1:' }}</a>
         {% else %}
-            <a href="{{ url }}?page={{ page_num }}&{{ page_params }}" class="button1 w3-bar-item">{{ page_num }}</a>
+            <a href="{{ url }}?page={{ page_num }}&{{ page_params }}" class="button1 w3-bar-item">{{ page_num}}</a>
         {% endif %}
     {% endfor %}
     {% if page.has_next %}

--- a/palanaeum/utils.py
+++ b/palanaeum/utils.py
@@ -14,11 +14,13 @@ def page_numbers_to_show(paginator, page):
     result sets, to limit the displayed pages to be within a few pages of the
     current/active page.
 
-    Returns a sequence of page numbers to be displayed. Uses '-1' as a sentinel
+    Returns a sequence of page numbers to be displayed. Uses '0' as a sentinel
     value to indicate a break in the sequence, when a '...' (ellipse) is
-    intended be displayed.
+    intended be displayed. Pages that are initially hidden are given as negative
+    numbers.
     """
     # implementation from https://www.technovelty.org/web/skipping-pages-with-djangocorepaginator.html
+    # It was tweaked to also return negative page numbers for pages that should be initially hidden
 
     # pages_wanted stores the pages we want to see, e.g.
     #  - first and second page always
@@ -40,21 +42,32 @@ def page_numbers_to_show(paginator, page):
     # pages outside the total number of pages we actually have.
     # Note that includes invalid negative and >page_range "context
     # pages" which we added above.
-    to_show = set(paginator.page_range).intersection(pages_wanted)
-    to_show = sorted(to_show)
+    to_show_initially = set(paginator.page_range).intersection(pages_wanted)
+
+    # Now we iterate through the paginator pages (the whole set) and put them 
+    # into our final list. If they are in to_show_initially, they should be 
+    # copied over unmodified. If they are not in that list, they should become
+    # negitive to show that they should be hidden initially.
+    to_show = []
+    for pg in paginator.page_range:
+        if pg in to_show_initially:
+            to_show.append(pg)
+        else:
+            to_show.append(pg * -1)
+
 
     # skip_pages will keep a list of page numbers from
     # pages_to_show that should have a skip-marker inserted
     # after them.  For flexibility this is done by looking for
-    # anywhere in the list that doesn't increment by 1 over the
-    # last entry.
+    # anywhere in the list that the item is less than the previous
+    # element (i.e. where we switch from positive to negative enumbers)
     skip_pages = [ x[1] for x in zip(to_show[:-1],
                                      to_show[1:])
-                   if (x[1] - x[0] != 1) ]
+                   if (x[1] < x[0]) ]
 
     # Each page in skip_pages should be follwed by a skip-marker
     # sentinel (e.g. -1).
     for i in skip_pages:
-        to_show.insert(to_show.index(i), -1)
+        to_show.insert(to_show.index(i), 0)
 
     return to_show

--- a/palanaeum/utils.py
+++ b/palanaeum/utils.py
@@ -59,11 +59,11 @@ def page_numbers_to_show(paginator, page):
     # skip_pages will keep a list of page numbers from
     # pages_to_show that should have a skip-marker inserted
     # after them.  For flexibility this is done by looking for
-    # anywhere in the list that the item is less than the previous
-    # element (i.e. where we switch from positive to negative enumbers)
+    # anywhere in the list that the next number is the negative 
+    # value of what it should be:(one more than the previous)
     skip_pages = [ x[1] for x in zip(to_show[:-1],
                                      to_show[1:])
-                   if (x[1] < x[0]) ]
+                   if (x[1] + x[0]) == -1]
 
     # Each page in skip_pages should be follwed by a skip-marker
     # sentinel (e.g. -1).


### PR DESCRIPTION
I'm still pretty new with git. I meant to add this into a new branch, but I committed before forking and somewhere along the way the branch got lost and it ended up on master. At this point I'm not sure how to fix this, but here's my code.

This change expands the ellipses of paginated pages when clicked, so that the range of pages that were hidden appear and can be clicked to navigate. I'm still new to Django and I welcome any feedback.