### PR TITLE
Fix URL sources not being displayed

### DIFF
--- a/palanaeum/models.py
+++ b/palanaeum/models.py
@@ -459,7 +459,7 @@ class Entry(TimeStampedModel, Content):
     def all_url_sources(self):
         if self.prefetched and self.prefetched_url_sources:
             return self.prefetched_url_sources
-        return self._get_opt_version_value('url_sources') or URLSource.objects.none()
+        return (self._get_opt_version_value('url_sources') or URLSource.objects.none()).distinct()
 
     @property
     def is_suggestion(self):
@@ -553,18 +553,10 @@ class Entry(TimeStampedModel, Content):
             entries_map[version_map[line.entry_version_id]].prefetched_lines.append(line)
 
         # Get URL sources
-        url_sources = {us.id: us for us in URLSource.all_visible.filter(entry_versions__id__in=entry_version_map.values()).distinct()}
-        if url_sources:
-            url_sources_id_list = ", ".join(map(str, url_sources.keys()))
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    "SELECT ev.entry_id, u2e.urlsource_id "
-                    "FROM palanaeum_urlsource_entry_versions u2e "
-                    "JOIN palanaeum_entryversion ev ON ev.id = u2e.entryversion_id "
-                    "WHERE u2e.urlsource_id IN ({})".format(url_sources_id_list))
-                for eid, uid in cursor.fetchall():
-                    if eid in entries_map:
-                        entries_map[eid].prefetched_url_sources.append(str(url_sources[uid]))
+        for source in URLSource.all_visible.filter(entry_versions__id__in=version_map.keys()).distinct():
+            for version in source.entry_versions.only('id'):
+                if version.id in version_map:
+                    entries_map[version_map[version.id]].prefetched_url_sources.append(source)
 
         return entries_map
 

--- a/palanaeum/models.py
+++ b/palanaeum/models.py
@@ -17,7 +17,7 @@ from django.contrib.postgres.fields import JSONField
 from django.contrib.postgres.indexes import GinIndex
 from django.core.exceptions import PermissionDenied
 from django.core.files.uploadedfile import UploadedFile
-from django.db import models, connection
+from django.db import models
 from django.db.models import Max, Count, Q
 from django.urls import reverse
 from django.utils import timezone

--- a/palanaeum/templates/palanaeum/elements/entry_editor.html
+++ b/palanaeum/templates/palanaeum/elements/entry_editor.html
@@ -109,7 +109,7 @@
                         </div>
                     </td>
                 </tr>
-                {% include 'palanaeum/elements/url_source_tr_form.html' with url_sources=entry.all_url_sources.all event=entry.event %}
+                {% include 'palanaeum/elements/url_source_tr_form.html' with url_sources=entry.all_url_sources event=entry.event %}
             </tbody>
         </table>
     </div>

--- a/palanaeum/templates/palanaeum/elements/entry_li.html
+++ b/palanaeum/templates/palanaeum/elements/entry_li.html
@@ -91,16 +91,16 @@
         {% if entry.note %}
             <small class="footnote">Footnote: {{ entry.note|safe }}</small>
         {% endif %}
-        {% if entry.tags.exists or entry.visible_url_sources or entry.direct_entry %}
+        {% if entry.tags.exists or entry.all_url_sources or entry.direct_entry %}
         <div class="w3-row">
             <div class="w3-col l8 m12 s12 w3-left">
                 {% include 'palanaeum/elements/tags_list.html' with tags=entry.tags.all %}
             </div>
-            {% if entry.visible_url_sources %}
+            {% if entry.all_url_sources %}
                 <div class="urls w3-col l4 m12 s12 w3-right">
                     {% autoescape off %}
                         Sources:
-                        {% for source in entry.visible_url_sources.all %}
+                        {% for source in entry.all_url_sources %}
                             {% if forloop.last %}
                                 {{ source.html }}
                             {% else %}

--- a/palanaeum/templates/palanaeum/feeds/entry_description.html
+++ b/palanaeum/templates/palanaeum/feeds/entry_description.html
@@ -21,11 +21,11 @@
         <p style="float:left">{% for tag in entry.tags.all %}{{ tag.as_link|safe }}{% if not forloop.last %}, {% endif %}{% endfor %}</p>
     {% endif %}
 
-    {% if entry.visible_url_sources %}
+    {% if entry.all_url_sources %}
         <p style="float:right">
             {% autoescape off %}
             Sources:
-            {% for source in entry.visible_url_sources.all %}
+            {% for source in entry.all_url_sources %}
                 {% if forloop.last %}
                     {{ source.html }}
                 {% else %}


### PR DESCRIPTION
As of commit af159fdb3a2e466e3b42dee06a685c57a2cdda11, URL sources were no longer visible in the entry view, because the code was in fact not quite dead. This reintroduces the URL sources display and adjusts the prefetching method for URL sources slightly.