### PR TITLE
Made 'optional' checkbox appear for everyone in its own table column

### DIFF
--- a/palanaeum/static/palanaeum/js/audio_player.js
+++ b/palanaeum/static/palanaeum/js/audio_player.js
@@ -301,7 +301,9 @@ const snippet_tr_template = '\
     </td>\
     <td>\
         <input class="comment" maxlength="500">\
-        <input type="checkbox" class="optional">\
+    </td>\
+    <td>\
+        <input type="checkbox" class="optional" style="min-width:50px">\
     </td>\
     <td>\
         <a href="" class="entry-anchor">\
@@ -516,7 +518,7 @@ Snippet.prototype = {
             tr.find('.comment').prop('readonly', true);
             visibility_button.hide();
             del_button.hide();
-            optional_checkbox.hide();
+            optional_checkbox.attr("disabled", true); // disable checkbox rather than hide it
         }
 
         this.tr_elem = tr;

--- a/palanaeum/templates/palanaeum/staff/audio_source_edit.html
+++ b/palanaeum/templates/palanaeum/staff/audio_source_edit.html
@@ -103,7 +103,9 @@
                     <th class="w3-center">{% trans 'Ending' %}</th>
                     <th class="w3-center">
                         {% trans 'Snippet name' %}
-                        {% if user.is_staff %}({% trans "checkbox: is optional" %}){% endif %}
+                    </th>
+                    <th> <!-- Moved checkbox to its own column-->
+                        {% trans "Optional" %}
                     </th>
                     <th colspan="2" class="w3-center"></th> <!--Left intentionally blank-->
                 </tr>


### PR DESCRIPTION
So in the audio source edit, I moved the snippets' 'optional' checkbox to its own column and made it visible (but disabled) to all users.

@m-strzelczyk 