### PR TITLE
Prevent cycles in previous/next event links, fixes #77

### DIFF
--- a/palanaeum/models.py
+++ b/palanaeum/models.py
@@ -377,15 +377,15 @@ class Event(Taggable, Content):
         return reverse('view_event', args=(self.id, slugify(self.name)))
 
     def get_next_url(self):
-        next_event = Event.all_visible.filter(date__lte=self.date)\
-            .exclude(pk=self.pk).values_list("id", "name").first()
+        next_event = Event.all_visible.filter(Q(date__gt=self.date) | Q(date__exact=self.date, id__gt=self.id))\
+            .order_by('date', 'id').values_list("id", "name").first()
 
         if next_event:
             return reverse('view_event', args=(next_event[0], slugify(next_event[1])))
 
     def get_prev_url(self):
-        prev_event = Event.all_visible.filter(date__gte=self.date)\
-            .exclude(pk=self.pk).values_list("id", "name").last()
+        prev_event = Event.all_visible.filter(Q(date__lt=self.date) | Q(date__exact=self.date, id__lt=self.id))\
+            .order_by('-date', '-id').values_list("id", "name").first()
 
         if prev_event:
             return reverse('view_event', args=(prev_event[0], slugify(prev_event[1])))

--- a/palanaeum/views.py
+++ b/palanaeum/views.py
@@ -66,7 +66,7 @@ def events(request):
     if sort_form.is_valid():
         sort_by = sort_form.cleaned_data['sort_by']
         sort_ord = sort_form.cleaned_data['sort_ord']
-        all_events = all_events.order_by('{}{}'.format(sort_ord, sort_by), 'id')
+        all_events = all_events.order_by('{}{}'.format(sort_ord, sort_by), '{}id'.format(sort_ord))
     else:
         sort_by = 'date'
         sort_ord = '-'


### PR DESCRIPTION
This makes the event list ordering and the previous/next button behaviours match up. To generate a unique ordering, the buttons choose an event with an earlier (later) date and if the dates match, one with a lower (higher) ID. The event list has been amended to explicitly use the sort order for the ID sorting to match that ordering.